### PR TITLE
Fix a bug with 64bit windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,4 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 # gem 'debugger', group: [:development, :test]
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,5 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
+gem 'coffee-script-source', '1.8.0'


### PR DESCRIPTION
Gemfile should be changed for 64 bit windows.
And fixed the version of coffee-script-source to 1.8.0 for the error: `TypeError: Object doesn't support this property or method`.

See more information:
https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors
http://stackoverflow.com/questions/28312460/object-doesnt-support-this-property-or-method-rails-windows-64bit
